### PR TITLE
apply pressure if kmem is nearly full

### DIFF
--- a/module/spl/spl-osx.c
+++ b/module/spl/spl-osx.c
@@ -49,7 +49,7 @@ struct utsname utsname = { { 0 } };
 //extern struct machine_info      machine_info;
 
 unsigned int max_ncpus = 0;
-static uint64_t  total_memory = 0;
+uint64_t  total_memory = 0;
 
 
 #include <sys/types.h>


### PR DESCRIPTION
if we don't have a lower pressure_bytes_target already,
pressure_bytes_target reflects the differrence between
the os_mem_alloc sysctl and 98% of kmem's total_memory,
as set in spl-osx.c.

If there has never been pressure, arc can grow until there
is no longer any memory left in kmem, at which point
waiters proliferate, which (at least) causes system
response to crawl to a halt unless memory is freed up.
