### PR TITLE
revert ZOL changes that broke git describe - lundman is the king here as well

### DIFF
--- a/config/spl-meta.m4
+++ b/config/spl-meta.m4
@@ -38,7 +38,7 @@ AC_DEFUN([SPL_AC_META], [
 		if git rev-parse --git-dir > /dev/null 2>&1; then
 			_match="${SPL_META_NAME}-${SPL_META_VERSION}*"
 			_alias=$(git describe --match=${_match} 2>/dev/null)
-			_release=$(echo ${_alias}|cut -f3- -d'-'|sed 's/-/_/g')
+			_release=$(echo ${_alias}|cut -f3- -d'-')
 			if test -n "${_release}"; then
 				SPL_META_RELEASE=${_release}
 				_spl_ac_meta_type="git describe"


### PR DESCRIPTION
ZoL at some point in the past (https://github.com/zfsonlinux/zfs/commit/f6fb7651a0d05b357dc179cc4853263ce15da6ed#commitcomment-18202010) started to replace the "-" with an "_" to accomodate for rpm specifics. This is not needed on macOS née OS X and is hereby reversed.