### PR TITLE
SPL improvements related to zfs problem report https://github.com/openzfsonosx/zfs/issues/584

### DIFF
--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -301,7 +301,7 @@ static uint32_t kmem_reaping_idspace;
 /*
  * kmem tunables
  */
-static struct timespec kmem_reap_interval = {5, 0};
+static struct timespec kmem_reap_interval = {15, 0};
 int kmem_depot_contention = 3;	/* max failed tryenters per real interval */
 pgcnt_t kmem_reapahead = 0;	/* start reaping N pages before pageout */
 int kmem_panic = 1;		/* whether to panic on error */
@@ -4367,6 +4367,13 @@ void
 spl_free_reap_caches(void)
 {
 	// note: this may take some time
+	static hrtime_t last_reap = 0;
+	const hrtime_t reap_after = SEC2NSEC(60);
+	const hrtime_t curtime = gethrtime();
+
+	if (curtime - last_reap < reap_after)
+		return;
+
 	vmem_qcache_reap(zio_arena_parent);
 	kmem_reap();
 	vmem_qcache_reap(kmem_va_arena);

--- a/module/spl/spl-vmem.c
+++ b/module/spl/spl-vmem.c
@@ -1320,7 +1320,7 @@ spl_vmem_malloc_if_no_pressure(size_t size)
 	// The mutex serializes concurrent callers, providing time for
 	// the variables in spl_vmem_xnu_useful_bytes_free() to be updated.
 	mutex_enter(&vmem_xnu_alloc_lock);
-	if (spl_vmem_xnu_useful_bytes_free() > (MAX(size,16ULL*1024ULL*1024ULL))) {
+	if (spl_vmem_xnu_useful_bytes_free() > (MAX(size,1024ULL*1024ULL))) {
 		extern void *osif_malloc(uint64_t);
 		void *p = osif_malloc(size);
 		if (p != NULL) {

--- a/module/spl/spl-vmem.c
+++ b/module/spl/spl-vmem.c
@@ -1576,10 +1576,12 @@ vmem_xalloc(vmem_t *vmp, size_t size, size_t align_arg, size_t phase,
 			break;
 		mutex_exit(&vmp->vm_lock);
 
+#if 0
 		if (vmp->vm_cflags & VMC_IDENTIFIER)
 			kmem_reap_idspace();
 		else
 			kmem_reap();
+#endif
 
 		mutex_enter(&vmp->vm_lock);
 		if (vmflag & VM_NOSLEEP)


### PR DESCRIPTION
We don't need to reap so much.   It's wasteful.

Also, the requirement for 16 MiB of useful bytes free for conditional allocs is too conservative, and perversely results in lots of time waiting for xnu_alloc_throttled() to timeout.    One mebibyte appears to be sufficient headroom on a busy zfs system with 16 GiB of main memory, and on much smaller test VMs.   Heavy sequential writing has much higher throughput in the latter case.