### PR TITLE
fix git hash not showing up in kext_version

### DIFF
--- a/config/spl-meta.m4
+++ b/config/spl-meta.m4
@@ -37,7 +37,7 @@ AC_DEFUN([SPL_AC_META], [
 		SPL_META_RELEASE=_SPL_AC_META_GETVAL([RELEASE]);
 		if git rev-parse --git-dir > /dev/null 2>&1; then
 			_match="${SPL_META_NAME}-${SPL_META_VERSION}*"
-			_alias=$(git describe --match=${_match} 2>/dev/null)
+			_alias=$(git describe --tags --match=${_match} 2>/dev/null)
 			_release=$(echo ${_alias}|cut -f3- -d'-')
 			if test -n "${_release}"; then
 				SPL_META_RELEASE=${_release}


### PR DESCRIPTION
git describe only sees annotated tags by default, and as we match the name anyway, we can as well drop the requirement of annotation

After this commit, `sysctl spl.kext_version` will show the git commit hash information again.