### PR TITLE
Remove install instructions from Readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,16 +4,12 @@ This is spl.kext, the Solaris Portability Layer (SPL).
 
 ** spl.kext is a dependency of zfs.kext, so start with this repository.
 
-It is tested primarily on Mac OS X Sierra.
+It is tested primarily on MacOS Mojave.
 
 See http://openzfsonosx.org/ for more information.
 
-```
- # git clone https://github.com/openzfsonosx/spl.git
- # cd spl
- # ./autogen.sh
- # ./configure
- # make
-```
+Detailed compiling instructions can be found in the wiki:
+
+https://openzfsonosx.org/wiki/Install
 
 - lundman


### PR DESCRIPTION
As outlined here https://github.com/openzfsonosx/zfs/pull/630#issuecomment-374067475 and proposed in https://github.com/openzfsonosx/zfs/pull/688 - removes the installation instructions from the Readme